### PR TITLE
Added warning for AccountType.CLIENT

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -193,7 +193,10 @@ public class JDAImpl implements JDA
         setStatus(Status.LOGGING_IN);
         if (token == null || token.isEmpty())
             throw new LoginException("Provided token was null or empty!");
-
+            
+        if (getAccountType() == AccountType.CLIENT)
+            LOG.warn("AccountType.CLIENT will be removed in JDA v4 as it is against the Discord Terms of Service (https://discordapp.com/terms). Proceeding with the login process may get this account terminated.");
+        
         Map<String, String> previousContext = null;
         if (contextMap != null)
         {


### PR DESCRIPTION
JDAImpl#login() will now log a TOS violation warning when AccountType.CLIENT is being used

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [X] Other: No changes were made that mess around with functionality, but the change was made in "internal code," so /shrug

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Logging in with AccountType.CLIENT will now issue a Discord TOS violation and v4 removal warning with a link to the [Discord TOS](https://discordapp.com/terms).
